### PR TITLE
📝 Add WG charter

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+All members and activities of the User Success Workgroup are governed by the [Python Software Foundation Code of Conduct](https://policies.python.org/python.org/code-of-conduct/).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# user-success-wg
+# User Success Workgroup
+
+Welcome to the User Success Workgroup (WG) repository!
+
+Our charter can be found in the [WG-charter file in this repository](WG-charter.md).

--- a/WG-charter.md
+++ b/WG-charter.md
@@ -1,0 +1,104 @@
+# PSF User Success Workgroup Charter
+
+**Approved by the PSF board on**: Jun 10, 2024
+
+## Purpose & Common Goals
+
+A common practice in product-focused industries is to have designers,
+user experience, and usability experts guide and improve products from day one.
+As a community-led, open-source project, the Python language and many of its
+core projects and tooling have not had the opportunity or expertise to integrate
+such practices at the core of their development cycles/workflows.
+
+Since its inception, Python has gained much popularity and adoption, so much so
+that it now serves millions of users globally, steadily increasing yearly.
+Python is a versatile language that powers a wide range of applications and
+user groups.
+User-facing official Python resources should reflect and support these diverse
+needs; for example, the Python website should serve "pathways to success" for
+diverse users and their needs[^1].
+
+As such, the PSF would benefit from dedicated resources and initiatives to focus
+on user experience, accessibility, internationalization and localization,
+and other areas critical to providing a high-quality user experience while
+focusing on productivity, consistency, and effective evolution of Python.
+This will support the PSF's mission to grow a global community of Python users.
+
+The workgroup (WG) aims to identify guiding principles for a wide range of user
+experiences.
+Some of its goals include:
+
+* identify and address the currently known problems in the user onboarding
+  experience[^2]
+  * the initial focus would be the python.org website, then onboarding docs
+  for docs.python.org and packaging documentation (in collaboration with
+  existing volunteers and community groups)
+* apply UX (user experience) research professional resources to Python-related
+  resources and tools such as but not limited to python.org and PyPI[^3]
+* conduct user testing as needed to align with the PSF goals and mission and to
+  improve the overall user experience of Python resources and projects[^4]
+* build a body of expertise in User Experience that will be available to provide
+  advice and support to groups like PyPA or core Python in the future
+* support and empower translation and localization efforts of official Python
+  resources
+
+## Active Time
+
+Accessibility, user experience, and developer experience should continue
+throughout a project's lifecycle.
+Therefore, we propose that this WG operates in perpetuity.
+
+## Core Values & Internal Governance
+
+The Working Group's core values are:
+
+- Inclusion
+- Integrity
+- Collaboration
+- Empathy
+
+The Working Group’s initiatives shall be guided by the following principles:
+
+- Focus on the user experience independent of the tools
+- Follow human-centered and inclusive design principles
+- Focus on evergreen resources and adapt to changes over time
+- Prioritize accessibility best practices but knowing that the ultimate goal
+  is disability inclusion
+- Fulfill the mission of being global and responsive to different needs by region
+- The [PSF Code of Conduct](https://policies.python.org/python.org/code-of-conduct/) applies to all WG activities
+
+The initial Working Group would document existing, known usability issues and
+make recommendations to the PSF Board on budget and staffing needs for user
+experience testing, user experience research, design, accessibility,
+translation, localization, and related user success efforts.
+
+## Rules & Decision-Making Procedures
+
+The working group will use consent-based decision-making processes[^5].
+A chair or co-chairs will guide the meeting and decision-making within the group.
+
+A treasurer will work with the WG chair and the PSF to ensure fair and
+transparent use and reporting of the Working Group funds.
+
+## Communication Plan
+
+- The working group will meet monthly and
+- Communicate asynchronously as needed through email or other communication
+  channels they deem appropriate
+
+## List of Participants/Who We Are
+
+Participants will be a cross-section of user experience professionals,
+educators, accessibility, and global representatives.
+
+Co-chairs: Tania Allard and Jannis Leidel.
+
+[^1]: Often referred to as personas in the design and UX jargon
+
+[^2]: This can refer to newcomers to the language and the community
+
+[^3]: The WG will liaise with the existing project’s stakeholders or interested parties (vs. acting independently) to ensure alignment with the project and its community needs. Some examples of activities the WG could help with in these instances are providing advice, funding enhancements or related exploratory work, help with fundraising activities in alignment with the WG scope, or overseeing pieces of work within the WG scope.
+
+[^4]: Note, this does not include the Python language itself
+
+[^5]:  [https://www.sociocracyforall.org/consent-decision-making/](https://www.sociocracyforall.org/consent-decision-making/)


### PR DESCRIPTION
This PR adds the WG's charter as accepted by the PSF board in June 2024, as well as some small improvements to the README and points to the PSF CoC.